### PR TITLE
Add "Commons Clause" to licence

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,16 @@
-                    GNU GENERAL PUBLIC LICENSE
-                       Version 3, 29 June 2007
+“Commons Clause” License Condition v1.0
+
+The Software is provided to you by the Licensor under the License, as defined below, subject to the following condition.
+
+Without limiting other conditions in the License, the grant of rights under the License will not include, and the License does not grant to you, the right to Sell the Software.
+
+For purposes of the foregoing, “Sell” means practicing any or all of the rights granted to you under the License to provide to third parties, for a fee or other consideration (including without limitation fees for hosting or consulting/ support services related to the Software), a product or service whose value derives, entirely or substantially, from the functionality of the Software. Any license notice or attribution required by the License must also include this Commons Clause License Condition notice.
+
+Software: Apps Against Humanity 
+
+License: GNU GENERAL PUBLIC LICENSE Version 3, 29 June 2007
+
+Licensor: 52inc                                       
 
  Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies


### PR DESCRIPTION
The license needs this commons clause to be in the spirit of the creative commons license.